### PR TITLE
[bugfix][#1]路径字符串拼接问题

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,6 @@ import type { IPicGo } from 'picgo'
 import { S3Client, ListBucketsCommand, PutObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3'
 import { AppConfig, ConfigEnum } from './index.enum'
 import { UploaderConfig } from './config'
-import { resolve } from 'path'
 import { verifyConfig } from './utils'
 
 /**
@@ -76,7 +75,11 @@ export = (ctx: PicGo) => {
 
           try {
             // 格式化上传路径
-            let uri = resolve(storageKey, filename) // 格式: /md/1.png、md/1.png
+            let uri = storageKey + '/' +filename // 格式: /md/1.png、md/1.png
+            // replace "\" to "/"
+            uri = uri.replace(/\\/g, '/')
+            // replace "//" to "/"
+            uri = uri.replace(/\/\//g, '/')
             if (uri.startsWith('/')) {
               uri = uri.slice(1)
             }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e26b9828-5f4f-4f19-881e-a560254f7ee3)

resolve函数会返回本地绝对路径, 导致用路径会显示为 https://image.example.dev/C%3A%5CWINDOWS%5Csystem32%5Cblog%5C20241105104145.png